### PR TITLE
Re-enable the 1000 series

### DIFF
--- a/CRJ1000-EuroLite.xml
+++ b/CRJ1000-EuroLite.xml
@@ -22,7 +22,7 @@
 		<solve-weight idx="1" weight="10.0" />
 	</approach>
 
-	<cruise speed="560" alt="35000" fuel="0.8">
+	<cruise speed="447" alt="35000" fuel="0.8">
 		<control-setting axis="/controls/engines/engine[0]/throttle-lever" value="0.95" />
 		<control-setting axis="/controls/engines/engine[1]/throttle-lever" value="0.95" />
 		<control-setting axis="/controls/flight/flaps" value="0.0" />

--- a/CRJ1000.xml
+++ b/CRJ1000.xml
@@ -22,7 +22,7 @@
 		<solve-weight idx="1" weight="10.0" />
 	</approach>
 
-	<cruise speed="560" alt="35000" fuel="0.8">
+	<cruise speed="447" alt="35000" fuel="0.8">
 		<control-setting axis="/controls/engines/engine[0]/throttle-lever" value="0.95" />
 		<control-setting axis="/controls/engines/engine[1]/throttle-lever" value="0.95" />
 		<control-setting axis="/controls/flight/flaps" value="0.0" />


### PR DESCRIPTION
Currently CRJ1000 and CRJ1000-EuroLite crash while Launching by a non-verbose Yasim failure.
This change allows these two aircrafts to launch again

Best,
IH-COL
