### PR TITLE
Allow anti-ice off in the after engine start checklist when temperature is above freezing

### DIFF
--- a/Checklists/after-start.xml
+++ b/Checklists/after-start.xml
@@ -7,11 +7,25 @@
 		<name>Anti-ice Switches</name>
 		<value>ON below freezing</value>
 		<condition>
-			<and>
-				<property>/controls/anti-ice/wing-heat</property>
-				<property>/controls/anti-ice/engine[0]/inlet-heat</property>
-				<property>/controls/anti-ice/engine[1]/inlet-heat</property>
-			</and>
+			<or>
+				<and>
+					<property>/controls/anti-ice/wing-heat</property>
+					<property>/controls/anti-ice/engine[0]/inlet-heat</property>
+					<property>/controls/anti-ice/engine[1]/inlet-heat</property>
+					<less-than>
+						<property>/environment/temperature-degc</property>
+						<value>0</value>
+					</less-than>
+				</and>
+				<equals>
+					<property>/environment/temperature-degc</property>
+					<value>0</value>
+				</equals>
+				<greater-than>
+					<property>/environment/temperature-degc</property>
+					<value>0</value>
+				</greater-than>					
+			</or>
 		</condition>
 		<binding>
 			<command>property-assign</command>


### PR DESCRIPTION
The code got kind of messy, but it works.

Signed-off-by: Matthew Brades matthew.r.brades@googlemail.com
