### PR TITLE
Add empty CargoDoorFwd object to CRJ700 model

### DIFF
--- a/Models/CRJ700.ac
+++ b/Models/CRJ700.ac
@@ -18785,6 +18785,11 @@ refs 3
 50 0.686094 0.841088
 kids 0
 OBJECT poly
+name "CargoDoorFwd"
+numvert 0
+numsurf 0
+kids 0
+OBJECT poly
 name "CargoDoorCtr"
 texture "CRJ700-Blank.png"
 texrep 1 1


### PR DESCRIPTION
This avoids the warning message on CRJ700 startup about the
missing CargoDoorFwd on the CRJ700.

Note: This does not fix the number of cargo doors on the EICAS
display in the CRJ700, though.

Context information:

The CRJ700 has two cargo doors (CargoDoorCtr and CargoDoorAft)
while the CRJ900* and CRJ1000* have three cargo doors (CargoDoorFwd,
CargoDoorCtr, and CargoDoorAft).

Also, the number of emergency exits over the wing differs between
the models in CRJ700 family. Those are not being modelled yet, though.