### PR TITLE
Use the correct constant name for pi-simple-controller

### DIFF
--- a/Systems/CRJ700-autopilot.xml
+++ b/Systems/CRJ700-autopilot.xml
@@ -701,7 +701,7 @@
 		<output>controls/flight/elevator-trim</output>
 		<config>
 			<Kp>-0.05</Kp>
-			<Ti>-0.10</Ti>
+			<Ki>-0.001</Ki>
 		</config>
 		<min>-1</min>
 		<max>1</max>


### PR DESCRIPTION
The Pitch controller of type pi-simple-controller had two constants
defined: Kp=-0.05 and Ti=-0.10.

This made no sense as a pi-simple-controller knows only the two
parameters Kp and Ki, not Ti, and thus the controller was actually
running as a purely proportional controller with Kp=-0.05 and Ki=0.0.

However, when following an ILS glideslope, the missing integration
term lets the aircraft drift below the glideslope.

Keeping the values Kp=-0.05 and Ki=-0.10 (changed from Ti to Ki)
make the AP able to follow an ILS glideslope, but it introduces
serious pitch oscillations at altitude hold at airspeeds over 220kts.

The values Kp=-0.05 and Ki=-0.001 appear to make the whole thing
kind of work for both altitude hold and following a glideslope.

More fine (and probably coarse) tuning needed after the FDM rework.