### PR TITLE
Bugfix: livery files not found

### DIFF
--- a/Nasal/effects.nas
+++ b/Nasal/effects.nas
@@ -3,7 +3,8 @@
 ###########################
 
 ## Livery select
-aircraft.livery.init("Models/Liveries/" ~ getprop("sim/aircraft"));
+var model_name = "CRJ" ~ substr(getprop("sim/aircraft"), 3);
+aircraft.livery.init("Models/Liveries/" ~ model_name);
 
 ## Switch sounds
 var Switch_sound = {


### PR DESCRIPTION
This addresses a problem where liveries aren't found on platforms with case-sensitive filenames (e.g., Linux) - the `model` property has "crj", while the livery files use "CRJ" (uppercase). The fix is overly simple, but it works and I couldn't come up with anything better.