### PR TITLE
Partially fix altimeter thousands

### DIFF
--- a/Models/Instruments/PFD/pfd.xml
+++ b/Models/Instruments/PFD/pfd.xml
@@ -659,6 +659,7 @@
 		<type>number-value</type>
 		<property alias="../../params/indicated-altitude-ft" />
 		<scale>0.001</scale>
+		<offset>0.025</offset>
 		<truncate type="bool">true</truncate>
 		<axis-alignment>yz-plane</axis-alignment>
 		<alignment>right-center</alignment>


### PR DESCRIPTION
This partially addresses #49; instead of flipping over exactly at 000, the thousands counter now flips over at 975, which is roughly the point where the "000" is inside the marker. A complete fix is going to be more elaborate though.