### PR TITLE
Fix fwd / ctr cargo doors

### DIFF
--- a/Models/CRJ1000.xml
+++ b/Models/CRJ1000.xml
@@ -380,7 +380,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>
@@ -437,7 +437,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>
@@ -464,7 +464,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>25</dep>
+				<dep>30</dep>
 			</entry>
 		</interpolation>
 		<center>

--- a/Models/CRJ700.xml
+++ b/Models/CRJ700.xml
@@ -371,7 +371,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>

--- a/Models/CRJ900.xml
+++ b/Models/CRJ900.xml
@@ -370,7 +370,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>
@@ -427,7 +427,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>


### PR DESCRIPTION
Cargo door animations caused the fwd and ctr cargo doors to float below the aircraft belly; this fix makes them slide along the fuselage like they should (I think). Tested only on the 1000; 700 and 900 assume to work, but should be verified.