### PR TITLE
Make cargo bay weight influence FDM weights

### DIFF
--- a/CRJ1000.xml
+++ b/CRJ1000.xml
@@ -175,5 +175,7 @@
         <weight x="14.94" y="0.0" z="-1.0" mass-prop="/sim/weight[0]/weight-lb" solve-weight="1" idx="0" />
         <!-- PAX/Cargo -->
         <weight x="3.5" y="0.0" z="-1.0" mass-prop="/sim/weight[1]/weight-lb" solve-weight="1" idx="1" />
+        <weight x="5" y="0.0" z="-2.0" mass-prop="/sim/weight[2]/weight-lb" solve-weight="1" idx="2" />
+        <weight x="-5" y="0.0" z="-2.0" mass-prop="/sim/weight[3]/weight-lb" solve-weight="1" idx="3" />
 
 </airplane>

--- a/CRJ1000ER.xml
+++ b/CRJ1000ER.xml
@@ -175,5 +175,7 @@
         <weight x="14.94" y="0.0" z="-1.0" mass-prop="/sim/weight[0]/weight-lb" solve-weight="1" idx="0" />
         <!-- PAX/Cargo -->
         <weight x="3.5" y="0.0" z="-1.0" mass-prop="/sim/weight[1]/weight-lb" solve-weight="1" idx="1" />
+        <weight x="5" y="0.0" z="-2.0" mass-prop="/sim/weight[2]/weight-lb" solve-weight="1" idx="2" />
+        <weight x="-5" y="0.0" z="-2.0" mass-prop="/sim/weight[3]/weight-lb" solve-weight="1" idx="3" />
 
 </airplane>


### PR DESCRIPTION
Changing cargo loads in the "Fuel and Payload" dialog didn't influence total mass and FDM behavior, so it was actually impossible to overload the aircraft. This was because the cargo weights weren't forwarded to the FDM. This patch fixes that for the 1000 and 1000ER; other types probably need the same or similar fix, but I haven't looked at those yet.