### PR TITLE
Autopilot improvements

### DIFF
--- a/CRJ700-main.xml
+++ b/CRJ700-main.xml
@@ -527,6 +527,12 @@
 			<target-roll-deg>0</target-roll-deg>
 			<target-pitch-deg>0</target-pitch-deg>
 			<target-climb-rate-fpm>0</target-climb-rate-fpm>
+
+            <!-- need to initialize these to avoid NaN in PID controller: -->
+            <fms>
+                <track-error-norm>0</track-error-norm>
+                <track-error-norm-lookahead>0</track-error-norm-lookahead>
+            </fms>
 		</internal>
 	</autopilot>
 	

--- a/Nasal/instrumentation.nas
+++ b/Nasal/instrumentation.nas
@@ -233,6 +233,356 @@ var nav_annunciator = func ()
 setlistener("autopilot/internal/vor1-captured", nav_annunciator, 0, 0);
 setlistener("autopilot/internal/vor2-captured", nav_annunciator, 0, 0);
 
+var mk_coords = func (lat, lon)
+{
+    var c = geo.Coord.new();
+    c.set_latlon(lat, lon);
+    return c;
+}
+
+var fdm_set_target_radial = func (radial)
+{
+    if (radial == 'auto' or radial == '') {
+        setprop("autopilot/internal/target/radial", -1);
+        setprop("autopilot/internal/target/capmode", "homing");
+    }
+    else {
+        setprop("autopilot/internal/target/radial", radial);
+        setprop("autopilot/internal/target/capmode", "intercept");
+    }
+}
+
+var get_std_turn_radius = func (airspeed) {
+    return airspeed / (15 * math.pi);
+}
+
+var fdm_configure_hold = func (fp, mode, phase)
+{
+    if (fp == nil) return;
+    var wpid = fp.current;
+    var wp = fp.getWP(wpid);
+    if (wp == nil) return;
+    var my_coords = mk_coords(
+        getprop("position/latitude-deg"),
+        getprop("position/longitude-deg"));
+    var wp_coords = mk_coords(wp.lat, wp.lon);
+    var target_dist = my_coords.distance_to(wp_coords) * M2NM;
+    var my_course = getprop("orientation/track-deg");
+    var pattern_speed = 230; # TODO: get real speed
+    var turn_radius = get_std_turn_radius(pattern_speed);
+    var leg_len_nm = 4; # arbitrary default
+    if (!wp.hold_is_distance) {
+        leg_len_nm = wp.hold_time_or_distance * pattern_speed / 3600;
+    }
+    else {
+        leg_len_nm = wp.hold_time_or_distance;
+    }
+    var radial_fwd = wp.hold_inbound_radial;
+    var radial_rev = geo.normdeg(radial_fwd + 180);
+    var diagonal_angle = R2D * math.atan2(2 * turn_radius, leg_len_nm);
+    var diagonal_fwd = radial_fwd;
+    if (wp.hold_is_left_handed) {
+        diagonal_fwd = geo.normdeg(radial_fwd - diagonal_angle);
+    }
+    else {
+        diagonal_fwd = geo.normdeg(radial_fwd + diagonal_angle);
+    }
+    var diagonal_rev = geo.normdeg(diagonal_fwd + 180);
+
+    var mapping =
+            { "hold":
+                { "inbound": [ "F", radial_fwd ]
+                , "outbound": [ "O", radial_rev ]
+                }
+            , "direct":
+                { "approach": [ "F", 'auto' ]
+                , "outbound": [ "O", radial_rev ]
+                }
+            , "teardrop":
+                { "approach": [ "F", 'auto' ]
+                , "diagonal": [ "O", diagonal_rev ]
+                },
+            , "parallel":
+                { "approach": [ "F", 'auto' ]
+                , "reverse": [ "X", radial_rev ]
+                , "diagonal": [ "F", diagonal_fwd ]
+                }
+            };
+
+    var selection = mapping[mode][phase];
+    var target = selection[0];
+    var radial = selection[1];
+
+    var target_coords = mk_coords(wp.lat, wp.lon);
+    if (target == "X" or target == "O") {
+        target_coords.apply_course_distance(radial_rev, leg_len_nm * NM2M);
+    }
+    if (target == "O") {
+        if (wp.hold_is_left_handed) {
+            target_coords.apply_course_distance(radial_fwd - 90, 2 * turn_radius * NM2M);
+        }
+        else {
+            target_coords.apply_course_distance(radial_fwd + 90, 2 * turn_radius * NM2M);
+        }
+    }
+    setprop("autopilot/internal/target/lat", target_coords.lat());
+    setprop("autopilot/internal/target/lon", target_coords.lon());
+    fdm_set_target_radial(radial);
+    setprop("autopilot/internal/target/id", wpid);
+    setprop("autopilot/internal/target/mode", mode);
+    setprop("autopilot/internal/target/phase", phase);
+    # no turn anticipation in pattern
+    setprop("autopilot/internal/target/anticipate", 0);
+}
+
+var fdm_configure_target = func (fp, wpid)
+{
+    if (fp == nil) return;
+    var wp = fp.getWP(wpid);
+    if (wp == nil) return;
+    if (wp.fly_type == "Hold") {
+        var my_coords = mk_coords(
+            getprop("position/latitude-deg"),
+            getprop("position/longitude-deg"));
+        var wp_coords = mk_coords(wp.lat, wp.lon);
+        var target_bearing = my_coords.course_to(wp_coords);
+        var my_course = getprop("orientation/track-deg");
+        var turn_heading = geo.normdeg180(target_bearing - my_course);
+
+        if (math.abs(turn_heading) >= 85) {
+            # We're moving away from the fix; this means we've already entered
+            # the holding area.
+            # So we will decide our hold entry procedure based on current
+            # heading relative to the holding radial, and we will jump directly
+            # to the second phase of the hold entry pattern.
+            var heading_diff = wp.hold_inbound_radial - my_course;
+            if (wp.hold_is_left_handed) {
+                heading_diff = -heading_diff;
+            }
+            if (math.abs(heading_diff) <= 90) {
+                # direct entry
+                fdm_configure_hold(fp, "hold", "outbound");
+            }
+            else if (heading_diff > 0) {
+                # parallel entry
+                fdm_configure_hold(fp, "parallel", "reverse");
+            }
+            else {
+                # teardrop entry
+                fdm_configure_hold(fp, "teardrop", "diagonal");
+            }
+        }
+        else {
+            # We're moving towards the fix; this means we have yet to enter the
+            # holding area, so we will start with the approach phase of the
+            # holding entry pattern.
+            var heading_diff = wp.hold_inbound_radial - target_bearing;
+            if (wp.hold_is_left_handed) {
+                heading_diff = -heading_diff;
+            }
+            if (math.abs(heading_diff) <= 90) {
+                # direct entry
+                fdm_configure_hold(fp, "direct", "approach");
+            }
+            else if (heading_diff > 0) {
+                # parallel entry
+                fdm_configure_hold(fp, "parallel", "approach");
+            }
+            else {
+                # teardrop entry
+                fdm_configure_hold(fp, "teardrop", "approach");
+            }
+        }
+    }
+    else {
+        var leg_bearing = wp.leg_bearing;
+        setprop("autopilot/internal/target/lat", wp.lat);
+        setprop("autopilot/internal/target/lon", wp.lon);
+        fdm_set_target_radial(leg_bearing);
+        setprop("autopilot/internal/target/id", wpid);
+        setprop("autopilot/internal/target/mode", "normal");
+        setprop("autopilot/internal/target/phase", "approach");
+        if (wp.fly_type == "flyBy") {
+            if (wpid + 1 >= fp.getPlanSize()) {
+                # last leg in plan, nothing to anticipate
+                setprop("autopilot/internal/target/anticipate", 0);
+            }
+            else {
+                var next_wp = fp.getWP(wpid + 1);
+                if (next_wp.fly_type == "Hold") {
+                    # approaching a holding pattern, no turn anticipation
+                    setprop("autopilot/internal/target/anticipate", 0);
+                }
+                else {
+                    # next leg is a normal one, enable turn anticipation
+                    setprop("autopilot/internal/target/anticipate", math.abs(next_wp.leg_bearing - wp.leg_bearing));
+                }
+            }
+        }
+        else {
+            # current leg is a fly-over, no turn anticipation
+            setprop("autopilot/internal/target/anticipate", 0);
+        }
+    }
+}
+
+var fdm_course_update = func ()
+{
+    if (getprop("autopilot/internal/target/lat") == nil or
+        getprop("autopilot/internal/target/lon") == nil)
+        return;
+    # get target coords
+    var target_fix = mk_coords(
+            getprop("autopilot/internal/target/lat"),
+            getprop("autopilot/internal/target/lon"));
+
+    # get aircraft position
+    var my_coords = mk_coords(
+        getprop("position/latitude-deg"),
+        getprop("position/longitude-deg"));
+    var my_course = getprop("orientation/track-deg");
+
+    # relative position towards fix
+    var target_course = my_coords.course_to(target_fix);
+    var target_dist = my_coords.distance_to(target_fix) * M2NM;
+    var capmode = getprop("autopilot/internal/target/capmode");
+    setprop("autopilot/internal/target/course", target_course);
+    setprop("autopilot/internal/target/dist", target_dist);
+    # default is to home in on the target wp
+    var course = target_course;
+    var airspeed = getprop("velocities/airspeed-kt");
+    var turn_radius = get_std_turn_radius(airspeed);
+    setprop("autopilot/internal/target/turn_radius", turn_radius);
+
+    if (capmode == "intercept" and target_dist > turn_radius) {
+        var target_radial = getprop("autopilot/internal/target/radial");
+        setprop("autopilot/internal/target/effective-radial", target_radial);
+
+        var bearing_err = geo.normdeg180(target_radial - target_course);
+        setprop("autopilot/internal/target/bearing_err", bearing_err);
+
+        var track_err = math.sin(D2R * bearing_err) * target_dist;
+        setprop("autopilot/internal/target/track_err", track_err);
+
+        if (math.abs(track_err) < 0.1 or
+            math.sgn(track_err) == math.sgn(geo.normdeg180(my_heading - target_radial))) {
+            # moving away from the target, or already on track; just align to
+            # target radial
+            course = target_radial;
+        }
+        else {
+            # moving towards the target; calculate interception course
+            var cos_course_err = math.max(math.cos(60), (turn_radius - math.abs(track_err)) / turn_radius);
+            var course_err = math.acos(cos_course_err) * R2D;
+            setprop("autopilot/internal/target/course_err", course_err);
+            if (track_err > 0) {
+                course = target_radial - course_err;
+            }
+            else {
+                course = target_radial + course_err;
+            }
+        }
+    }
+    else {
+        setprop("autopilot/internal/target/effective-radial", geo.normdeg(target_course));
+    }
+    setprop("autopilot/internal/target-crs", geo.normdeg(course));
+    setprop("autopilot/internal/target/effective-crs", geo.normdeg(course));
+}
+
+var fdm_next_target = func (fp)
+{
+    var mode = getprop("autopilot/internal/target/mode");
+    var phase = getprop("autopilot/internal/target/phase");
+
+    if (mode == "hold") {
+        if (phase == "outbound") {
+            fdm_configure_hold(fp, "hold", "inbound");
+        }
+        else {
+            fdm_configure_hold(fp, "hold", "outbound");
+        }
+    }
+    else if (mode == "parallel") {
+        if (phase == "approach") {
+            fdm_configure_hold(fp, "parallel", "reverse");
+        }
+        else if (phase == "reverse") {
+            fdm_configure_hold(fp, "parallel", "diagonal");
+        }
+        else {
+            # diagonal
+            fdm_configure_hold(fp, "hold", "inbound");
+        }
+    }
+    else if (mode == "teardrop") {
+        if (phase == "approach") {
+            fdm_configure_hold(fp, "teardrop", "diagonal");
+        }
+        else {
+            # diagonal
+            fdm_configure_hold(fp, "hold", "inbound");
+        }
+    }
+    else if (mode == "direct") {
+        fdm_configure_hold(fp, "hold", "outbound");
+    }
+    else {
+        # assume mode "normal"
+        var wpid = getprop("autopilot/internal/target/id");
+        fp.current = wpid + 1;
+    }
+}
+
+var fdm_update_target = func (fp)
+{
+    if (getprop("autopilot/internal/target/lat") == nil or
+        getprop("autopilot/internal/target/lon") == nil)
+        return;
+    var my_coords = mk_coords(
+        getprop("position/latitude-deg"),
+        getprop("position/longitude-deg"));
+    var target_coords = mk_coords(
+        getprop("autopilot/internal/target/lat"),
+        getprop("autopilot/internal/target/lon"));
+    var airspeed = getprop("velocities/airspeed-kt");
+    var turn_radius = get_std_turn_radius(airspeed);
+    var capmode = getprop("autopilot/internal/target/capmode");
+    var leg_bearing = 'auto';
+    if (capmode == "intercept") {
+        leg_bearing = getprop("autopilot/internal/target/radial");
+    }
+    var turn_anticipation_dist = 0;
+    if (leg_bearing != 'auto') {
+        var anticipation_angle = getprop("autopilot/internal/target/anticipate");
+        if (math.abs(anticipation_angle) > 90) {
+            turn_anticipation_dist = turn_radius;
+        }
+        else {
+            turn_anticipation_dist =
+                turn_radius *
+                    math.tan(0.5 * D2R * math.abs(anticipation_angle));
+        }
+    }
+    var target_dist =
+            my_coords.distance_to(target_coords) * M2NM;
+    if (target_dist <= turn_anticipation_dist or target_dist < 0.1) {
+        fdm_next_target(fp);
+    }
+}
+
+var fdm_update = func ()
+{
+    var fp = flightplan();
+    var configured_wpid = getprop("autopilot/internal/target/id");
+    var current_wpid = fp.current;
+    if (configured_wpid != current_wpid) {
+        fdm_configure_target(fp, current_wpid);
+    }
+    fdm_update_target(fp);
+    fdm_course_update();
+}
+
 var vs_annunciator = func () 
 {
 	var ref = sprintf("%1.1f", getprop("controls/autoflight/vertical-speed-select")/1000);

--- a/Nasal/instrumentation.nas
+++ b/Nasal/instrumentation.nas
@@ -248,8 +248,8 @@ var update_fms_info = func()
     var course_to_wp = courseAndDist[0];
     var dist_to_wp = courseAndDist[1];
     var track_error_deg = geo.normdeg180(wp0.leg_bearing - course_to_wp);
-    var cdi_deflection = math.clamp(-track_error_deg, -10, 10);
     var track_error = math.sin(track_error_deg * D2R) * dist_to_wp;
+    var cdi_deflection = math.clamp(-track_error * 3, -10, 10);
     var suggested_intercept_heading = geo.normdeg(course_to_wp + 3.0 * cdi_deflection);
     var turn_radius = getprop("velocities/groundspeed-kt") / (30 * math.pi);
     setprop("autopilot/internal/fms/course", wp0.leg_bearing);

--- a/Nasal/instrumentation.nas
+++ b/Nasal/instrumentation.nas
@@ -233,354 +233,49 @@ var nav_annunciator = func ()
 setlistener("autopilot/internal/vor1-captured", nav_annunciator, 0, 0);
 setlistener("autopilot/internal/vor2-captured", nav_annunciator, 0, 0);
 
-var mk_coords = func (lat, lon)
-{
-    var c = geo.Coord.new();
-    c.set_latlon(lat, lon);
-    return c;
-}
-
-var fdm_set_target_radial = func (radial)
-{
-    if (radial == 'auto' or radial == '') {
-        setprop("autopilot/internal/target/radial", -1);
-        setprop("autopilot/internal/target/capmode", "homing");
-    }
-    else {
-        setprop("autopilot/internal/target/radial", radial);
-        setprop("autopilot/internal/target/capmode", "intercept");
-    }
-}
-
-var get_std_turn_radius = func (airspeed) {
-    return airspeed / (15 * math.pi);
-}
-
-var fdm_configure_hold = func (fp, mode, phase)
-{
-    if (fp == nil) return;
-    var wpid = fp.current;
-    var wp = fp.getWP(wpid);
-    if (wp == nil) return;
-    var my_coords = mk_coords(
-        getprop("position/latitude-deg"),
-        getprop("position/longitude-deg"));
-    var wp_coords = mk_coords(wp.lat, wp.lon);
-    var target_dist = my_coords.distance_to(wp_coords) * M2NM;
-    var my_course = getprop("orientation/track-deg");
-    var pattern_speed = 230; # TODO: get real speed
-    var turn_radius = get_std_turn_radius(pattern_speed);
-    var leg_len_nm = 4; # arbitrary default
-    if (!wp.hold_is_distance) {
-        leg_len_nm = wp.hold_time_or_distance * pattern_speed / 3600;
-    }
-    else {
-        leg_len_nm = wp.hold_time_or_distance;
-    }
-    var radial_fwd = wp.hold_inbound_radial;
-    var radial_rev = geo.normdeg(radial_fwd + 180);
-    var diagonal_angle = R2D * math.atan2(2 * turn_radius, leg_len_nm);
-    var diagonal_fwd = radial_fwd;
-    if (wp.hold_is_left_handed) {
-        diagonal_fwd = geo.normdeg(radial_fwd - diagonal_angle);
-    }
-    else {
-        diagonal_fwd = geo.normdeg(radial_fwd + diagonal_angle);
-    }
-    var diagonal_rev = geo.normdeg(diagonal_fwd + 180);
-
-    var mapping =
-            { "hold":
-                { "inbound": [ "F", radial_fwd ]
-                , "outbound": [ "O", radial_rev ]
-                }
-            , "direct":
-                { "approach": [ "F", 'auto' ]
-                , "outbound": [ "O", radial_rev ]
-                }
-            , "teardrop":
-                { "approach": [ "F", 'auto' ]
-                , "diagonal": [ "O", diagonal_rev ]
-                },
-            , "parallel":
-                { "approach": [ "F", 'auto' ]
-                , "reverse": [ "X", radial_rev ]
-                , "diagonal": [ "F", diagonal_fwd ]
-                }
-            };
-
-    var selection = mapping[mode][phase];
-    var target = selection[0];
-    var radial = selection[1];
-
-    var target_coords = mk_coords(wp.lat, wp.lon);
-    if (target == "X" or target == "O") {
-        target_coords.apply_course_distance(radial_rev, leg_len_nm * NM2M);
-    }
-    if (target == "O") {
-        if (wp.hold_is_left_handed) {
-            target_coords.apply_course_distance(radial_fwd - 90, 2 * turn_radius * NM2M);
-        }
-        else {
-            target_coords.apply_course_distance(radial_fwd + 90, 2 * turn_radius * NM2M);
-        }
-    }
-    setprop("autopilot/internal/target/lat", target_coords.lat());
-    setprop("autopilot/internal/target/lon", target_coords.lon());
-    fdm_set_target_radial(radial);
-    setprop("autopilot/internal/target/id", wpid);
-    setprop("autopilot/internal/target/mode", mode);
-    setprop("autopilot/internal/target/phase", phase);
-    # no turn anticipation in pattern
-    setprop("autopilot/internal/target/anticipate", 0);
-}
-
-var fdm_configure_target = func (fp, wpid)
-{
-    if (fp == nil) return;
-    var wp = fp.getWP(wpid);
-    if (wp == nil) return;
-    if (wp.fly_type == "Hold") {
-        var my_coords = mk_coords(
-            getprop("position/latitude-deg"),
-            getprop("position/longitude-deg"));
-        var wp_coords = mk_coords(wp.lat, wp.lon);
-        var target_bearing = my_coords.course_to(wp_coords);
-        var my_course = getprop("orientation/track-deg");
-        var turn_heading = geo.normdeg180(target_bearing - my_course);
-
-        if (math.abs(turn_heading) >= 85) {
-            # We're moving away from the fix; this means we've already entered
-            # the holding area.
-            # So we will decide our hold entry procedure based on current
-            # heading relative to the holding radial, and we will jump directly
-            # to the second phase of the hold entry pattern.
-            var heading_diff = wp.hold_inbound_radial - my_course;
-            if (wp.hold_is_left_handed) {
-                heading_diff = -heading_diff;
-            }
-            if (math.abs(heading_diff) <= 90) {
-                # direct entry
-                fdm_configure_hold(fp, "hold", "outbound");
-            }
-            else if (heading_diff > 0) {
-                # parallel entry
-                fdm_configure_hold(fp, "parallel", "reverse");
-            }
-            else {
-                # teardrop entry
-                fdm_configure_hold(fp, "teardrop", "diagonal");
-            }
-        }
-        else {
-            # We're moving towards the fix; this means we have yet to enter the
-            # holding area, so we will start with the approach phase of the
-            # holding entry pattern.
-            var heading_diff = wp.hold_inbound_radial - target_bearing;
-            if (wp.hold_is_left_handed) {
-                heading_diff = -heading_diff;
-            }
-            if (math.abs(heading_diff) <= 90) {
-                # direct entry
-                fdm_configure_hold(fp, "direct", "approach");
-            }
-            else if (heading_diff > 0) {
-                # parallel entry
-                fdm_configure_hold(fp, "parallel", "approach");
-            }
-            else {
-                # teardrop entry
-                fdm_configure_hold(fp, "teardrop", "approach");
-            }
-        }
-    }
-    else {
-        var leg_bearing = wp.leg_bearing;
-        setprop("autopilot/internal/target/lat", wp.lat);
-        setprop("autopilot/internal/target/lon", wp.lon);
-        fdm_set_target_radial(leg_bearing);
-        setprop("autopilot/internal/target/id", wpid);
-        setprop("autopilot/internal/target/mode", "normal");
-        setprop("autopilot/internal/target/phase", "approach");
-        if (wp.fly_type == "flyBy") {
-            if (wpid + 1 >= fp.getPlanSize()) {
-                # last leg in plan, nothing to anticipate
-                setprop("autopilot/internal/target/anticipate", 0);
-            }
-            else {
-                var next_wp = fp.getWP(wpid + 1);
-                if (next_wp.fly_type == "Hold") {
-                    # approaching a holding pattern, no turn anticipation
-                    setprop("autopilot/internal/target/anticipate", 0);
-                }
-                else {
-                    # next leg is a normal one, enable turn anticipation
-                    setprop("autopilot/internal/target/anticipate", math.abs(next_wp.leg_bearing - wp.leg_bearing));
-                }
-            }
-        }
-        else {
-            # current leg is a fly-over, no turn anticipation
-            setprop("autopilot/internal/target/anticipate", 0);
-        }
-    }
-}
-
-var fdm_course_update = func ()
-{
-    if (getprop("autopilot/internal/target/lat") == nil or
-        getprop("autopilot/internal/target/lon") == nil)
-        return;
-    # get target coords
-    var target_fix = mk_coords(
-            getprop("autopilot/internal/target/lat"),
-            getprop("autopilot/internal/target/lon"));
-
-    # get aircraft position
-    var my_coords = mk_coords(
-        getprop("position/latitude-deg"),
-        getprop("position/longitude-deg"));
-    var my_course = getprop("orientation/track-deg");
-
-    # relative position towards fix
-    var target_course = my_coords.course_to(target_fix);
-    var target_dist = my_coords.distance_to(target_fix) * M2NM;
-    var capmode = getprop("autopilot/internal/target/capmode");
-    setprop("autopilot/internal/target/course", target_course);
-    setprop("autopilot/internal/target/dist", target_dist);
-    # default is to home in on the target wp
-    var course = target_course;
-    var airspeed = getprop("velocities/airspeed-kt");
-    var turn_radius = get_std_turn_radius(airspeed);
-    setprop("autopilot/internal/target/turn_radius", turn_radius);
-
-    if (capmode == "intercept" and target_dist > turn_radius) {
-        var target_radial = getprop("autopilot/internal/target/radial");
-        setprop("autopilot/internal/target/effective-radial", target_radial);
-
-        var bearing_err = geo.normdeg180(target_radial - target_course);
-        setprop("autopilot/internal/target/bearing_err", bearing_err);
-
-        var track_err = math.sin(D2R * bearing_err) * target_dist;
-        setprop("autopilot/internal/target/track_err", track_err);
-
-        if (math.abs(track_err) < 0.1 or
-            math.sgn(track_err) == math.sgn(geo.normdeg180(my_heading - target_radial))) {
-            # moving away from the target, or already on track; just align to
-            # target radial
-            course = target_radial;
-        }
-        else {
-            # moving towards the target; calculate interception course
-            var cos_course_err = math.max(math.cos(60), (turn_radius - math.abs(track_err)) / turn_radius);
-            var course_err = math.acos(cos_course_err) * R2D;
-            setprop("autopilot/internal/target/course_err", course_err);
-            if (track_err > 0) {
-                course = target_radial - course_err;
-            }
-            else {
-                course = target_radial + course_err;
-            }
-        }
-    }
-    else {
-        setprop("autopilot/internal/target/effective-radial", geo.normdeg(target_course));
-    }
-    setprop("autopilot/internal/target-crs", geo.normdeg(course));
-    setprop("autopilot/internal/target/effective-crs", geo.normdeg(course));
-}
-
-var fdm_next_target = func (fp)
-{
-    var mode = getprop("autopilot/internal/target/mode");
-    var phase = getprop("autopilot/internal/target/phase");
-
-    if (mode == "hold") {
-        if (phase == "outbound") {
-            fdm_configure_hold(fp, "hold", "inbound");
-        }
-        else {
-            fdm_configure_hold(fp, "hold", "outbound");
-        }
-    }
-    else if (mode == "parallel") {
-        if (phase == "approach") {
-            fdm_configure_hold(fp, "parallel", "reverse");
-        }
-        else if (phase == "reverse") {
-            fdm_configure_hold(fp, "parallel", "diagonal");
-        }
-        else {
-            # diagonal
-            fdm_configure_hold(fp, "hold", "inbound");
-        }
-    }
-    else if (mode == "teardrop") {
-        if (phase == "approach") {
-            fdm_configure_hold(fp, "teardrop", "diagonal");
-        }
-        else {
-            # diagonal
-            fdm_configure_hold(fp, "hold", "inbound");
-        }
-    }
-    else if (mode == "direct") {
-        fdm_configure_hold(fp, "hold", "outbound");
-    }
-    else {
-        # assume mode "normal"
-        var wpid = getprop("autopilot/internal/target/id");
-        fp.current = wpid + 1;
-    }
-}
-
-var fdm_update_target = func (fp)
-{
-    if (getprop("autopilot/internal/target/lat") == nil or
-        getprop("autopilot/internal/target/lon") == nil)
-        return;
-    var my_coords = mk_coords(
-        getprop("position/latitude-deg"),
-        getprop("position/longitude-deg"));
-    var target_coords = mk_coords(
-        getprop("autopilot/internal/target/lat"),
-        getprop("autopilot/internal/target/lon"));
-    var airspeed = getprop("velocities/airspeed-kt");
-    var turn_radius = get_std_turn_radius(airspeed);
-    var capmode = getprop("autopilot/internal/target/capmode");
-    var leg_bearing = 'auto';
-    if (capmode == "intercept") {
-        leg_bearing = getprop("autopilot/internal/target/radial");
-    }
-    var turn_anticipation_dist = 0;
-    if (leg_bearing != 'auto') {
-        var anticipation_angle = getprop("autopilot/internal/target/anticipate");
-        if (math.abs(anticipation_angle) > 90) {
-            turn_anticipation_dist = turn_radius;
-        }
-        else {
-            turn_anticipation_dist =
-                turn_radius *
-                    math.tan(0.5 * D2R * math.abs(anticipation_angle));
-        }
-    }
-    var target_dist =
-            my_coords.distance_to(target_coords) * M2NM;
-    if (target_dist <= turn_anticipation_dist or target_dist < 0.1) {
-        fdm_next_target(fp);
-    }
-}
-
-var fdm_update = func ()
+var update_fms_info = func()
 {
     var fp = flightplan();
-    var configured_wpid = getprop("autopilot/internal/target/id");
-    var current_wpid = fp.current;
-    if (configured_wpid != current_wpid) {
-        fdm_configure_target(fp, current_wpid);
+    var wp0 = fp.currentWP();
+    if (wp0 == nil) {
+        return;
     }
-    fdm_update_target(fp);
-    fdm_course_update();
+    var current_course = getprop("orientation/heading-deg");
+    var course_error = geo.normdeg180(current_course - wp0.leg_bearing);
+    var courseAndDist = wp0.courseAndDistanceFrom(
+                            getprop("position/latitude-deg"),
+                            getprop("position/longitude-deg"));
+    var course_to_wp = courseAndDist[0];
+    var dist_to_wp = courseAndDist[1];
+    var track_error_deg = geo.normdeg180(wp0.leg_bearing - course_to_wp);
+    var cdi_deflection = math.clamp(-track_error_deg, -10, 10);
+    var track_error = math.sin(track_error_deg * D2R) * dist_to_wp;
+    var suggested_intercept_heading = geo.normdeg(course_to_wp + 3.0 * cdi_deflection);
+    var turn_radius = getprop("velocities/groundspeed-kt") / (30 * math.pi);
+    setprop("autopilot/internal/fms/course", wp0.leg_bearing);
+    setprop("autopilot/internal/fms/course-error", course_error);
+    setprop("autopilot/internal/fms/turn-radius", turn_radius);
+    setprop("autopilot/internal/fms/wp-dist", dist_to_wp);
+    setprop("autopilot/internal/fms/wp-course", course_to_wp);
+    setprop("autopilot/internal/fms/wp-fly-type", wp0.fly_type);
+    setprop("autopilot/internal/fms/track-error-deg", track_error_deg);
+    setprop("autopilot/internal/fms/track-error", track_error);
+    setprop("instrumentation/fms/radials/selected-deg", wp0.leg_bearing);
+    setprop("instrumentation/fms/radials/actual-deg", wp0.leg_bearing);
+    setprop("instrumentation/fms/radials/target-radial-deg", wp0.leg_bearing);
+    setprop("instrumentation/fms/radials/target-auto-heading-deg", suggested_intercept_heading);
+    if (wp0.fly_type == "flyBy") {
+        if (dist_to_wp != nil and turn_radius != nil and dist_to_wp < turn_radius) {
+            printf("%f < %f: Next waypoint.", dist_to_wp, turn_radius);
+            fp.current = fp.current + 1;
+        }
+        else if (dist_to_wp == nil) {
+            print("dist_to_wp is nil");
+        }
+        else if (turn_radius == nil) {
+            print("turn_radius is nil");
+        }
+    }
 }
 
 var vs_annunciator = func () 

--- a/Nasal/master.nas
+++ b/Nasal/master.nas
@@ -109,7 +109,7 @@ var fast_loop = Loop(0, func {
 	# Instruments.
 	eicas_messages_page1.update();
 	eicas_messages_page2.update();
-    CRJ700.update_fms_info();
+	CRJ700.update_fms_info();
 
 	# Model.
 	wipers[0].update();

--- a/Nasal/master.nas
+++ b/Nasal/master.nas
@@ -109,6 +109,7 @@ var fast_loop = Loop(0, func {
 	# Instruments.
 	eicas_messages_page1.update();
 	eicas_messages_page2.update();
+    CRJ700.fdm_update();
 
 	# Model.
 	wipers[0].update();

--- a/Nasal/master.nas
+++ b/Nasal/master.nas
@@ -109,7 +109,7 @@ var fast_loop = Loop(0, func {
 	# Instruments.
 	eicas_messages_page1.update();
 	eicas_messages_page2.update();
-    CRJ700.fdm_update();
+    CRJ700.update_fms_info();
 
 	# Model.
 	wipers[0].update();

--- a/Systems/CRJ700-autopilot.xml
+++ b/Systems/CRJ700-autopilot.xml
@@ -4,646 +4,675 @@
 <!-- Autopilot configuration -->
 
 <!--
-	Properties:
-	/controls/autoflight/autopilot/engage			autopilot on/off
-	/controls/autoflight/flight-director/engage		flight director on/off
-	
-	/autopilot/internal/roll-mode			basic roll mode
-	/autopilot/ref/roll-hdg		basic roll mode heading setting
-	/autopilot/ref/roll-deg			basic roll mode roll setting
-	/controls/autoflight/pitch-select			basic pitch mode setting
-	/controls/autoflight/altitude-select			altitude setting
-	/autopilot/internal/bank-limit-deg			bank angle setting
-	/controls/autoflight/heading-select			heading setting
-	/controls/autoflight/mach-select			mach speed setting
-	/controls/autoflight/speed-select			IAS speed setting
-	/controls/autoflight/vertical-speed-select		vertical speed seting
-	
-	/controls/autoflight/lat-mode			lateral mode
-	/controls/autoflight/vert-mode			vertical mode
-	/controls/autoflight/speed-mode			speed mode
-	/controls/autoflight/nav-source				nav mode
-	
-	
-	Speed modes:
-	0	IAS
-	1	mach
-	
-	Lateral modes:
-	0	basic roll mode
-	1	heading
-	2	navigation (see nav modes)
-	3	approach
-	#4	back course
-	#5	1/2 bank (inhibited when in TO/GA, approach or nav mode)
-	6	take off mode
-	7	go around mode
-	
-	Nav source:
-	0	VOR1 intercept
-	1	VOR2 intercept
-	2	FMS(1) course
-	
-	Vertical modes:
-	0	basic pitch mode
-	1	altitude (hold)
-	2	vertical speed
-	3	altitude (track)
-	#4	speed mode (this is NOT an auto throttle but a vertical (pitch) mode!)
-	5	glideslope mode
-	6	TO mode
-	7	GA mode
+    Properties:
+    /controls/autoflight/autopilot/engage           autopilot on/off
+    /controls/autoflight/flight-director/engage     flight director on/off
+
+    /autopilot/internal/roll-mode               basic roll mode
+    /autopilot/ref/roll-hdg                     basic roll mode heading setting
+    /autopilot/ref/roll-deg                     basic roll mode roll setting
+    /controls/autoflight/pitch-select           basic pitch mode setting
+    /controls/autoflight/altitude-select        altitude setting
+    /autopilot/internal/bank-limit-deg          bank angle setting
+    /controls/autoflight/heading-select         heading setting
+    /controls/autoflight/mach-select            mach speed setting
+    /controls/autoflight/speed-select           IAS speed setting
+    /controls/autoflight/vertical-speed-select  vertical speed seting
+
+    /controls/autoflight/lat-mode           lateral mode
+    /controls/autoflight/vert-mode          vertical mode
+    /controls/autoflight/speed-mode         speed mode
+    /controls/autoflight/nav-sour
+
+
+    Speed modes:
+    0   IAS
+    1   mach
+
+    Lateral modes:
+    0   basic roll mode
+    1   heading
+    2   navigation (see nav modes)
+    3   approach
+    #4  back course
+    #5  1/2 bank (inhibited when in TO/GA, approach or nav mode)
+    6   take off mode
+    7   go around mode
+
+    Nav source:
+    0   VOR1 intercept
+    1   VOR2 intercept
+    2   FMS(1) course
+
+    Vertical modes:
+    0   basic pitch mode
+    1   altitude (hold)
+    2   vertical speed
+    3   altitude (track)
+    #4  speed mode (this is NOT an auto throttle but a vertical (pitch) mode!)
+    5   glideslope mode
+    6   TO mode
+    7   GA mode
 -->
 
 <PropertyList>
-	
+
     <!-- Internal computers -->
     <filter>
-		<name>Heading bug error computer/normalizer</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>1</gain>
-		<input>
-			<property>controls/autoflight/heading-select</property>
-			<offset>
-				<property>instrumentation/heading-indicator[0]/indicated-heading-deg</property>
-				<scale>-1</scale>
-			</offset>
-		</input>
-		<output>autopilot/internal/heading-bug-error-deg</output>
-		<period>
-			<min>-180</min>
-			<max>180</max>
-		</period>
-	</filter>
+        <name>Heading bug error computer/normalizer</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <input>
+            <property>controls/autoflight/heading-select</property>
+            <offset>
+                <property>instrumentation/heading-indicator[0]/indicated-heading-deg</property>
+                <scale>-1</scale>
+            </offset>
+        </input>
+        <output>autopilot/internal/heading-bug-error-deg</output>
+        <period>
+            <min>-180</min>
+            <max>180</max>
+        </period>
+    </filter>
+    <!--
     <filter>
-		<name>True heading bug error computer/normalizer</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>1</gain>
-		<input>
-			<property>autopilot/internal/target-crs</property>
-			<offset>
-				<property>orientation/heading-deg</property>
-				<scale>-1</scale>
-			</offset>
-		</input>
-		<output>autopilot/internal/true-heading-error-deg</output>
-		<period>
-			<min>-180</min>
-			<max>180</max>
-		</period>
-	</filter>
+        <name>True heading bug error computer/normalizer</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <input>
+            <property>autopilot/internal/target-crs</property>
+            <offset>
+                <property>orientation/heading-deg</property>
+                <scale>-1</scale>
+            </offset>
+        </input>
+        <output>autopilot/internal/true-heading-error-deg</output>
+        <period>
+            <min>-180</min>
+            <max>180</max>
+        </period>
+    </filter>
+    -->
     <filter>
-		<name>Roll mode heading error computer/normalizer</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>1</gain>
-		<input>
-			<property>autopilot/ref/roll-hdg</property>
-			<offset>
-				<property>instrumentation/heading-indicator[0]/indicated-heading-deg</property>
-				<scale>-1</scale>
-			</offset>
-		</input>
-		<output>autopilot/internal/roll-mode-heading-error-deg</output>
-		<period>
-			<min>-180</min>
-			<max>180</max>
-		</period>
-	</filter>
+        <name>Standard turn radius</name>
+        <type>gain</type>
+        <gain>0.01061032953945969</gain>
+        <input>
+            <property>velocities/groundspeed-kt</property>
+        </input>
+        <output>autopilot/internal/turn-radius</output>
+    </filter>
     <filter>
-		<name>VOR1 heading error computer/normalizer</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>1</gain>
-		<input>
-			<property>instrumentation/nav[0]/radials/target-auto-hdg-deg</property> <!-- FIXME: Bad property to use -->
-			<offset>
-				<property>orientation/heading-deg</property>
-				<!-- Using indicated heading isn't accurate enough for precision VOR tracking (e.g. ILS) -->
-				<!--property>instrumentation/heading-indicator[0]/indicated-heading-deg</property-->
-				<scale>-1</scale>
-			</offset>
-		</input>
-		<output>autopilot/internal/nav1-heading-error-deg</output>
-		<period>
-			<min>-180</min>
-			<max>180</max>
-		</period>
-	</filter>
+        <name>Roll mode heading error computer/normalizer</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <input>
+            <property>autopilot/ref/roll-hdg</property>
+            <offset>
+                <property>instrumentation/heading-indicator[0]/indicated-heading-deg</property>
+                <scale>-1</scale>
+            </offset>
+        </input>
+        <output>autopilot/internal/roll-mode-heading-error-deg</output>
+        <period>
+            <min>-180</min>
+            <max>180</max>
+        </period>
+    </filter>
     <filter>
-		<name>VOR2 heading error computer/normalizer</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>1</gain>
-		<input>
-			<property>instrumentation/nav[1]/radials/target-auto-hdg-deg</property>
-			<offset>
-				<property>orientation/heading-deg</property>
-				<!-- Using indicated heading isn't accurate enough for precision VOR tracking (e.g. ILS) -->
-				<!--property>instrumentation/heading-indicator[0]/indicated-heading-deg</property-->
-				<scale>-1</scale>
-			</offset>
-		</input>
-		<output>autopilot/internal/nav2-heading-error-deg</output>
-		<period>
-			<min>-180</min>
-			<max>180</max>
-		</period>
-	</filter>
-	<!-- speed predictors -->
+        <name>VOR1 heading error computer/normalizer</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <input>
+            <property>instrumentation/nav[0]/radials/target-auto-hdg-deg</property>
+            <offset>
+                <property>orientation/heading-deg</property>
+                <!-- Using indicated heading isn't accurate enough for precision VOR tracking (e.g. ILS) -->
+                <!--property>instrumentation/heading-indicator[0]/indicated-heading-deg</property-->
+                <scale>-1</scale>
+            </offset>
+        </input>
+        <output>autopilot/internal/nav1-heading-error-deg</output>
+        <period>
+            <min>-180</min>
+            <max>180</max>
+        </period>
+    </filter>
+    <filter>
+        <name>VOR2 heading error computer/normalizer</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <input>
+            <property>instrumentation/nav[1]/radials/target-auto-hdg-deg</property>
+            <offset>
+                <property>orientation/heading-deg</property>
+                <!-- Using indicated heading isn't accurate enough for precision VOR tracking (e.g. ILS) -->
+                <!--property>instrumentation/heading-indicator[0]/indicated-heading-deg</property-->
+                <scale>-1</scale>
+            </offset>
+        </input>
+        <output>autopilot/internal/nav2-heading-error-deg</output>
+        <period>
+            <min>-180</min>
+            <max>180</max>
+        </period>
+    </filter>
+    <filter>
+        <name>FMS heading error computer/normalizer</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <input>
+            <property>instrumentation/fms/radials/target-auto-heading-deg</property>
+            <offset>
+                <property>orientation/heading-deg</property>
+                <scale>-1</scale>
+            </offset>
+        </input>
+        <output>autopilot/internal/fms1-heading-error-deg</output>
+        <period>
+            <min>-180</min>
+            <max>180</max>
+        </period>
+    </filter>
+    <!-- speed predictors -->
     <predict-simple>
-		<name>5-second airspeed predictor</name>
-		<debug type="bool">false</debug>
-		<seconds>5</seconds>
-		<filter-gain>0</filter-gain>
-		<input>velocities/airspeed-kt</input>
-		<output>autopilot/internal/lookahead-5-sec-airspeed-kt</output>
-	</predict-simple>
-	<predict-simple>
-		<name>5-second mach predictor</name>
-		<debug type="bool">false</debug>
-		<seconds>5</seconds>
-		<filter-gain>0</filter-gain>
-		<input>velocities/mach</input>
-		<output>autopilot/internal/lookahead-5-sec-airspeed-mach</output>
-	</predict-simple>
-	
+        <name>5-second airspeed predictor</name>
+        <debug type="bool">false</debug>
+        <seconds>5</seconds>
+        <filter-gain>0</filter-gain>
+        <input>velocities/airspeed-kt</input>
+        <output>autopilot/internal/lookahead-5-sec-airspeed-kt</output>
+    </predict-simple>
+    <predict-simple>
+        <name>5-second mach predictor</name>
+        <debug type="bool">false</debug>
+        <seconds>5</seconds>
+        <filter-gain>0</filter-gain>
+        <input>velocities/mach</input>
+        <output>autopilot/internal/lookahead-5-sec-airspeed-mach</output>
+    </predict-simple>
+
     <!-- VNAV vertical speed advisory -->
     <pi-simple-controller>
-		<name>VNAV advisory controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<property>autopilot/route-manager/active</property>
-		</enable>
-		<input>
-			<property>instrumentation/altimeter[0]/indicated-altitude-ft</property>
-		</input>
-		<reference>
-			<property>autopilot/route-manager/vnav/target-altitude-ft</property>
-		</reference>
-		<output>autopilot/route-manager/vnav/target-climb-rate-fpm</output>
-		<min>-2000</min>
-		<max>2000</max>
-		<config>
-			<Kp>18</Kp>
-			<Ki>0</Ki>
-		</config>
-	</pi-simple-controller>
-	
+        <name>VNAV advisory controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <property>autopilot/route-manager/active</property>
+        </enable>
+        <input>
+            <property>instrumentation/altimeter[0]/indicated-altitude-ft</property>
+        </input>
+        <reference>
+            <property>autopilot/route-manager/vnav/target-altitude-ft</property>
+        </reference>
+        <output>autopilot/route-manager/vnav/target-climb-rate-fpm</output>
+        <min>-2000</min>
+        <max>2000</max>
+        <config>
+            <Kp>18</Kp>
+            <Ki>0</Ki>
+        </config>
+    </pi-simple-controller>
+
     <!-- Main controllers -->
     <logic>
-		<name>Autopilot engaged</name>
-		<input>
-			<and>
-				<property>autopilot/autoflight-serviceable</property>
-				<property>controls/autoflight/autopilot/engage</property>
-				<greater-than>
-					<property>systems/DC/outputs/afcs-l</property>
-					<value>15</value>
-				</greater-than>
-			</and>
-		</input>
-		<output>autopilot/internal/autoflight-engaged</output>
-	</logic>
+        <name>Autopilot engaged</name>
+        <input>
+            <and>
+                <property>autopilot/autoflight-serviceable</property>
+                <property>controls/autoflight/autopilot/engage</property>
+                <greater-than>
+                    <property>systems/DC/outputs/afcs-l</property>
+                    <value>15</value>
+                </greater-than>
+            </and>
+        </input>
+        <output>autopilot/internal/autoflight-engaged</output>
+    </logic>
     <logic>
-		<name>Flight director engaged</name>
-		<input>
-			<and>
-				<property>autopilot/flight-director-serviceable</property>
-				<property>controls/autoflight/flight-director/engage</property>
-				<greater-than>
-					<property>systems/DC/outputs/afcs-l</property>
-					<value>15</value>
-				</greater-than>
-			</and>
-		</input>
-		<output>autopilot/internal/flight-director-engaged</output>
-	</logic>
+        <name>Flight director engaged</name>
+        <input>
+            <and>
+                <property>autopilot/flight-director-serviceable</property>
+                <property>controls/autoflight/flight-director/engage</property>
+                <greater-than>
+                    <property>systems/DC/outputs/afcs-l</property>
+                    <value>15</value>
+                </greater-than>
+            </and>
+        </input>
+        <output>autopilot/internal/flight-director-engaged</output>
+    </logic>
     <logic>
-		<name>Autothrottle engaged</name>
-		<input>
-			<and>
-				<property>sim/config/allow-autothrottle</property>
-				<property>controls/autoflight/autothrottle-engage</property>
-				<greater-than>
-					<property>systems/DC/outputs/afcs-l</property>
-					<value>15</value>
-				</greater-than>
-			</and>
-		</input>
-		<output>autopilot/internal/autothrottle-engaged</output>
-	</logic>	
+        <name>Autothrottle engaged</name>
+        <input>
+            <and>
+                <property>sim/config/allow-autothrottle</property>
+                <property>controls/autoflight/autothrottle-engage</property>
+                <greater-than>
+                    <property>systems/DC/outputs/afcs-l</property>
+                    <value>15</value>
+                </greater-than>
+            </and>
+        </input>
+        <output>autopilot/internal/autothrottle-engaged</output>
+    </logic>
     <!-- Speed mode (or autothrottle, if configured in "cheat menu") -->
     <!-- 0 : IAS hold -->
     <pid-controller>
-		<name>IAS speed mode controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/autothrottle-engaged</property>
-					<equals>
-						<property>controls/autoflight/speed-mode</property>
-						<value>0</value>
-					</equals>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>autopilot/internal/lookahead-5-sec-airspeed-kt</property>
-		</input>
-		<reference>
-			<property>controls/autoflight/speed-select</property>
-		</reference>
-		<output>fcs/autopilot/throttle-cmd-norm</output>
-		<config>
-			<Kp>0.05</Kp>
-			<beta>1</beta>
-			<alpha>0.1</alpha>
-			<gamma>0</gamma>
-			<Ti>10</Ti>
-			<Td>0.00001</Td>
-			<u_min>0</u_min>
-			<u_max>1</u_max>
-		</config>
-	</pid-controller>
+        <name>IAS speed mode controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/autothrottle-engaged</property>
+                    <equals>
+                        <property>controls/autoflight/speed-mode</property>
+                        <value>0</value>
+                    </equals>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>autopilot/internal/lookahead-5-sec-airspeed-kt</property>
+        </input>
+        <reference>
+            <property>controls/autoflight/speed-select</property>
+        </reference>
+        <output>fcs/autopilot/throttle-cmd-norm</output>
+        <config>
+            <Kp>0.05</Kp>
+            <beta>1</beta>
+            <alpha>0.1</alpha>
+            <gamma>0</gamma>
+            <Ti>10</Ti>
+            <Td>0.00001</Td>
+            <u_min>0</u_min>
+            <u_max>1</u_max>
+        </config>
+    </pid-controller>
     <!-- 1 : Mach hold -->
     <pid-controller>
-		<name>Mach speed mode controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/autothrottle-engaged</property>
-					<equals>
-						<property>controls/autoflight/speed-mode</property>
-						<value>1</value>
-					</equals>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>autopilot/internal/lookahead-5-sec-airspeed-mach</property>
-		</input>
-		<reference>
-			<property>controls/autoflight/mach-select</property>
-		</reference>
-		<output>fcs/autopilot/throttle-cmd-norm</output>
-		<config>
-			<Kp>0.03</Kp>
-			<beta>1</beta>
-			<alpha>0.1</alpha>
-			<gamma>0</gamma>
-			<Ti>0.005</Ti>
-			<Td>0.00001</Td>
-			<u_min>0</u_min>
-			<u_max>1</u_max>
-		</config>
-	</pid-controller>
-	
+        <name>Mach speed mode controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/autothrottle-engaged</property>
+                    <equals>
+                        <property>controls/autoflight/speed-mode</property>
+                        <value>1</value>
+                    </equals>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>autopilot/internal/lookahead-5-sec-airspeed-mach</property>
+        </input>
+        <reference>
+            <property>controls/autoflight/mach-select</property>
+        </reference>
+        <output>fcs/autopilot/throttle-cmd-norm</output>
+        <config>
+            <Kp>0.03</Kp>
+            <beta>1</beta>
+            <alpha>0.1</alpha>
+            <gamma>0</gamma>
+            <Ti>0.005</Ti>
+            <Td>0.00001</Td>
+            <u_min>0</u_min>
+            <u_max>1</u_max>
+        </config>
+    </pid-controller>
+
     <!-- Lateral -->
     <!-- 0 : Basic roll mode -->
     <filter>
-		<name>Basic roll mode</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>1</gain>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/flight-director-engaged</property>
-					<or>
-						<equals>
-							<property>controls/autoflight/lat-mode</property>
-							<value>0</value>
-						</equals>
-						<equals>
-							<property>controls/autoflight/lat-mode</property>
-							<value>6</value>
-						</equals>
-						<equals>
-							<property>controls/autoflight/lat-mode</property>
-							<value>7</value>
-						</equals>
-					</or>
-					<equals>
-						<property>autopilot/internal/roll-mode</property>
-						<value>1</value>
-					</equals>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>autopilot/ref/roll-deg</property>
-		</input>
-		<output>autopilot/internal/target-roll-deg</output>
-	</filter>
+        <name>Basic roll mode</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/flight-director-engaged</property>
+                    <or>
+                        <equals>
+                            <property>controls/autoflight/lat-mode</property>
+                            <value>0</value>
+                        </equals>
+                        <equals>
+                            <property>controls/autoflight/lat-mode</property>
+                            <value>6</value>
+                        </equals>
+                        <equals>
+                            <property>controls/autoflight/lat-mode</property>
+                            <value>7</value>
+                        </equals>
+                    </or>
+                    <equals>
+                        <property>autopilot/internal/roll-mode</property>
+                        <value>1</value>
+                    </equals>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>autopilot/ref/roll-deg</property>
+        </input>
+        <output>autopilot/internal/target-roll-deg</output>
+    </filter>
     <!-- 1 : heading hold -->
-	<pi-simple-controller>
-		<name>Heading controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<property>autopilot/internal/flight-director-engaged</property>
-				<not>
-					<property>autopilot/internal/roll-mode</property>
-				</not>
-			</condition>
-		</enable>
-		<input>
-			<condition>
-				<equals>
-					<property>controls/autoflight/lat-mode</property>
-					<value>1</value>
-				</equals>
-			</condition>
-			<property>autopilot/internal/heading-bug-error-deg</property>
-		</input>
-		<input>
-			<condition>
-				<and>
-					<or>
-						<equals>
-							<property>controls/autoflight/lat-mode</property>
-							<value>0</value>
-						</equals>
-						<equals>
-							<property>controls/autoflight/lat-mode</property>
-							<value>6</value>
-						</equals>
-						<equals>
-							<property>controls/autoflight/lat-mode</property>
-							<value>7</value>
-						</equals>
-					</or>
-					<equals>
-						<property>autopilot/internal/roll-mode</property>
-						<value>0</value>
-					</equals>
-				</and>
-			</condition>
-			<property>autopilot/internal/roll-mode-heading-error-deg</property>
-		</input>
-		<reference>
-			<value>0</value>
-		</reference>
-		<output>autopilot/internal/target-roll-deg</output>
-		<config>
-			<Kp>-5</Kp>
-			<Ki>-0.1</Ki>
-		</config>
-		<min>
-			<property>autopilot/internal/bank-limit-deg</property>
-			<scale>-1</scale>
-		</min>
-		<max>
-			<property>autopilot/internal/bank-limit-deg</property>
-		</max>
-	</pi-simple-controller>
-
-	<!-- 2 : NAV/APPR -->
     <pi-simple-controller>
-		<name>NAV intercept controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/flight-director-engaged</property>
-					<or>
-						<and>
-							<equals>
-								<property>controls/autoflight/lat-mode</property>
-								<value>2</value>
-							</equals>
-							<greater-than>
-								<property>instrumentation/nav[0]/nav-distance</property>
-								<value>1852</value>
-							</greater-than>
-						</and>
-						<equals>
-							<property>controls/autoflight/lat-mode</property>
-							<value>3</value>
-						</equals>
-					</or>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<condition>
-				<equals>
-					<property>controls/autoflight/nav-source</property>
-					<value>0</value>
-				</equals>
-				<property>instrumentation/nav[0]/data-is-valid</property>
-			</condition>
-			<property>autopilot/internal/nav1-heading-error-deg</property>
-		</input>
-		<input>
-			<condition>
-				<equals>
-					<property>controls/autoflight/nav-source</property>
-					<value>1</value>
-				</equals>
-				<property>instrumentation/nav[1]/data-is-valid</property>
-			</condition>
-			<property>autopilot/internal/nav2-heading-error-deg</property>
-		</input>
-		<input>
-			<condition>
-				<and>
-					<equals>
-						<property>controls/autoflight/lat-mode</property>
-						<value>2</value>
-					</equals>
-					<equals>
-						<property>controls/autoflight/nav-source</property>
-						<value>2</value>
-					</equals>
-				</and>
-			</condition>
-			<property>autopilot/internal/true-heading-error-deg</property>
-		</input>
-		<reference>
-			<value>0</value>
-		</reference>
-		<output>autopilot/internal/target-roll-deg</output>
-		<config>
-			<Kp>-6</Kp>
-			<Ki>0</Ki>
-		</config>
-		<min>
-			<property>autopilot/internal/bank-limit-deg</property>
-			<scale>-1</scale>
-		</min>
-		<max>
-			<property>autopilot/internal/bank-limit-deg</property>
-		</max>
-	</pi-simple-controller>
+        <name>Heading controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <property>autopilot/internal/flight-director-engaged</property>
+                <not>
+                    <property>autopilot/internal/roll-mode</property>
+                </not>
+            </condition>
+        </enable>
+        <input>
+            <condition>
+                <equals>
+                    <property>controls/autoflight/lat-mode</property>
+                    <value>1</value>
+                </equals>
+            </condition>
+            <property>autopilot/internal/heading-bug-error-deg</property>
+        </input>
+        <input>
+            <condition>
+                <and>
+                    <or>
+                        <equals>
+                            <property>controls/autoflight/lat-mode</property>
+                            <value>0</value>
+                        </equals>
+                        <equals>
+                            <property>controls/autoflight/lat-mode</property>
+                            <value>6</value>
+                        </equals>
+                        <equals>
+                            <property>controls/autoflight/lat-mode</property>
+                            <value>7</value>
+                        </equals>
+                    </or>
+                    <equals>
+                        <property>autopilot/internal/roll-mode</property>
+                        <value>0</value>
+                    </equals>
+                </and>
+            </condition>
+            <property>autopilot/internal/roll-mode-heading-error-deg</property>
+        </input>
+        <reference>
+            <value>0</value>
+        </reference>
+        <output>autopilot/internal/target-roll-deg</output>
+        <config>
+            <Kp>-5</Kp>
+            <Ki>-0.1</Ki>
+        </config>
+        <min>
+            <property>autopilot/internal/bank-limit-deg</property>
+            <scale>-1</scale>
+        </min>
+        <max>
+            <property>autopilot/internal/bank-limit-deg</property>
+        </max>
+    </pi-simple-controller>
+
+    <!-- 2 : NAV/APPR -->
+    <pi-simple-controller>
+        <name>NAV intercept controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/flight-director-engaged</property>
+                    <or>
+                        <and>
+                            <equals>
+                                <property>controls/autoflight/lat-mode</property>
+                                <value>2</value>
+                            </equals>
+                            <greater-than>
+                                <property>instrumentation/nav[0]/nav-distance</property>
+                                <value>1852</value>
+                            </greater-than>
+                        </and>
+                        <equals>
+                            <property>controls/autoflight/lat-mode</property>
+                            <value>3</value>
+                        </equals>
+                    </or>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <condition>
+                <equals>
+                    <property>controls/autoflight/nav-source</property>
+                    <value>0</value>
+                </equals>
+                <property>instrumentation/nav[0]/data-is-valid</property>
+            </condition>
+            <property>autopilot/internal/nav1-heading-error-deg</property>
+        </input>
+        <input>
+            <condition>
+                <equals>
+                    <property>controls/autoflight/nav-source</property>
+                    <value>1</value>
+                </equals>
+                <property>instrumentation/nav[1]/data-is-valid</property>
+            </condition>
+            <property>autopilot/internal/nav2-heading-error-deg</property>
+        </input>
+        <input>
+            <condition>
+                <and>
+                    <equals>
+                        <property>controls/autoflight/lat-mode</property>
+                        <value>2</value>
+                    </equals>
+                    <equals>
+                        <property>controls/autoflight/nav-source</property>
+                        <value>2</value>
+                    </equals>
+                </and>
+            </condition>
+            <property>autopilot/internal/fms1-heading-error-deg</property>
+        </input>
+        <reference>
+            <value>0</value>
+        </reference>
+        <output>autopilot/internal/target-roll-deg</output>
+        <config>
+            <Kp>-5</Kp>
+            <Ki>-0.1</Ki>
+        </config>
+        <min>
+            <property>autopilot/internal/bank-limit-deg</property>
+            <scale>-1</scale>
+        </min>
+        <max>
+            <property>autopilot/internal/bank-limit-deg</property>
+        </max>
+    </pi-simple-controller>
 
     <pid-controller>
-		<name>Approach vertical controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/flight-director-engaged</property>
-					<equals>
-						<property>controls/autoflight/lat-mode</property>
-						<value>3</value>
-					</equals>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>5</value>
-					</equals>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>instrumentation/nav[0]/gs-rate-of-climb-fpm</property>
-		</input>
-		<reference>
-			<property>instrumentation/vertical-speed-indicator[0]/indicated-speed-fpm</property>
-		</reference>
-		<output>autopilot/internal/target-pitch-deg</output>
-		<config>
-			<Kp>-0.004</Kp>
-			<beta>0.1</beta>
-			<alpha>0.1</alpha>
-			<gamma>0</gamma>
-			<Ti>10</Ti>
-			<Td>0.00001</Td>
-			<u_min>-8</u_min>
-			<u_max>5</u_max>
-		</config>
-	</pid-controller>
-	
-	<!-- Vertical -->
+        <name>Approach vertical controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/flight-director-engaged</property>
+                    <equals>
+                        <property>controls/autoflight/lat-mode</property>
+                        <value>3</value>
+                    </equals>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>5</value>
+                    </equals>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/nav[0]/gs-rate-of-climb-fpm</property>
+        </input>
+        <reference>
+            <property>instrumentation/vertical-speed-indicator[0]/indicated-speed-fpm</property>
+        </reference>
+        <output>autopilot/internal/target-pitch-deg</output>
+        <config>
+            <Kp>-0.004</Kp>
+            <beta>0.1</beta>
+            <alpha>0.1</alpha>
+            <gamma>0</gamma>
+            <Ti>10</Ti>
+            <Td>0.00001</Td>
+            <u_min>-8</u_min>
+            <u_max>5</u_max>
+        </config>
+    </pid-controller>
+
+    <!-- Vertical -->
     <!-- 0 : Basic pitch mode -->
     <filter>
-		<name>Basic pitch mode</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>1</gain>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/flight-director-engaged</property>
-					<or>
-						<equals>
-							<property>controls/autoflight/vert-mode</property>
-							<value>0</value>
-						</equals>
-						<equals>
-							<property>controls/autoflight/vert-mode</property>
-							<value>6</value>
-						</equals>
-						<equals>
-							<property>controls/autoflight/vert-mode</property>
-							<value>7</value>
-						</equals>
-					</or>
-					<not>
-						<equals>
-							<property>controls/autoflight/lat-mode</property>
-							<value>3</value><!-- approach mode -->
-						</equals>
-					</not>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>controls/autoflight/pitch-select</property>
-		</input>
-		<output>autopilot/internal/target-pitch-deg</output>
-	</filter>
+        <name>Basic pitch mode</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/flight-director-engaged</property>
+                    <or>
+                        <equals>
+                            <property>controls/autoflight/vert-mode</property>
+                            <value>0</value>
+                        </equals>
+                        <equals>
+                            <property>controls/autoflight/vert-mode</property>
+                            <value>6</value>
+                        </equals>
+                        <equals>
+                            <property>controls/autoflight/vert-mode</property>
+                            <value>7</value>
+                        </equals>
+                    </or>
+                    <not>
+                        <equals>
+                            <property>controls/autoflight/lat-mode</property>
+                            <value>3</value><!-- approach mode -->
+                        </equals>
+                    </not>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>controls/autoflight/pitch-select</property>
+        </input>
+        <output>autopilot/internal/target-pitch-deg</output>
+    </filter>
     <!-- 1 : Altitude -->
     <pi-simple-controller>
-		<name>Altitude controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/flight-director-engaged</property>
-					<or>
-						<equals>
-							<property>controls/autoflight/vert-mode</property>
-							<value>1</value>
-						</equals>
-						<equals>
-							<property>controls/autoflight/vert-mode</property>
-							<value>3</value>
-						</equals>
-					</or>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>instrumentation/altimeter[0]/indicated-altitude-ft</property>
-		</input>
-		<reference>
-			<property>autopilot/ref/alt-hold</property>
-		</reference>
-		<output>autopilot/internal/target-climb-rate-fpm</output>
-		<min>-1500</min>
-		<max>1500</max>
-		<config>
-			<Kp>6.6</Kp>
-			<Ki>0</Ki>
-		</config>
-	</pi-simple-controller>
+        <name>Altitude controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/flight-director-engaged</property>
+                    <or>
+                        <equals>
+                            <property>controls/autoflight/vert-mode</property>
+                            <value>1</value>
+                        </equals>
+                        <equals>
+                            <property>controls/autoflight/vert-mode</property>
+                            <value>3</value>
+                        </equals>
+                    </or>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/altimeter[0]/indicated-altitude-ft</property>
+        </input>
+        <reference>
+            <property>autopilot/ref/alt-hold</property>
+        </reference>
+        <output>autopilot/internal/target-climb-rate-fpm</output>
+        <min>-1500</min>
+        <max>1500</max>
+        <config>
+            <Kp>6.6</Kp>
+            <Ki>0</Ki>
+        </config>
+    </pi-simple-controller>
     <!-- 2 : Vertical speed -->
     <filter>
-		<name>Vertical speed controller</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>1</gain>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/flight-director-engaged</property>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>2</value>
-					</equals>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>controls/autoflight/vertical-speed-select</property>
-		</input>
-		<output>autopilot/internal/target-climb-rate-fpm</output>
-	</filter>
+        <name>Vertical speed controller</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>1</gain>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/flight-director-engaged</property>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>2</value>
+                    </equals>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>controls/autoflight/vertical-speed-select</property>
+        </input>
+        <output>autopilot/internal/target-climb-rate-fpm</output>
+    </filter>
     <!-- 4 : IAS hold -->
     <pi-simple-controller>
-		<name>IAS controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/flight-director-engaged</property>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>4</value>
-					</equals>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
-		</input>
-		<reference>
-			<property>controls/autoflight/speed-select</property>
-		</reference>
-		<output>autopilot/internal/target-pitch-deg</output>
-		<min>-8</min>
-		<max>10</max>
-		<config>
-			<Kp>-1.1</Kp>
-			<Ki>-0.015</Ki>
-		</config>
-	</pi-simple-controller>	
+        <name>IAS controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/flight-director-engaged</property>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>4</value>
+                    </equals>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
+        </input>
+        <reference>
+            <property>controls/autoflight/speed-select</property>
+        </reference>
+        <output>autopilot/internal/target-pitch-deg</output>
+        <min>-8</min>
+        <max>10</max>
+        <config>
+            <Kp>-1.1</Kp>
+            <Ki>-0.015</Ki>
+        </config>
+    </pi-simple-controller>
     <!-- Pitch and roll controllers -->
     <pid-controller>
         <name>Vertical speed to pitch controller</name>
@@ -686,200 +715,200 @@
 
     <!--
     <pi-simple-controller>
-		<name>Vertical speed to pitch controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<or>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>1</value> 
-					</equals>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>2</value> 
-					</equals>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>3</value> 
-					</equals>
-				</or>
-			</condition>
-		</enable>
-		<input>
-			<property>instrumentation/vertical-speed-indicator[0]/indicated-speed-fpm</property>
-		</input>
-		<reference>
-			<property>autopilot/internal/target-climb-rate-fpm</property>
-		</reference>
-		<output>autopilot/internal/target-pitch-deg</output>
-		<config>
-			<Kp>0.002</Kp>
-			<Ki>0.00075</Ki>
-		</config>
-		<min>-10</min>
-		<max>10</max>
-	</pi-simple-controller>	
+        <name>Vertical speed to pitch controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <or>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>1</value>
+                    </equals>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>2</value>
+                    </equals>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>3</value>
+                    </equals>
+                </or>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/vertical-speed-indicator[0]/indicated-speed-fpm</property>
+        </input>
+        <reference>
+            <property>autopilot/internal/target-climb-rate-fpm</property>
+        </reference>
+        <output>autopilot/internal/target-pitch-deg</output>
+        <config>
+            <Kp>0.002</Kp>
+            <Ki>0.00075</Ki>
+        </config>
+        <min>-10</min>
+        <max>10</max>
+    </pi-simple-controller>
     -->
     <pid-controller>
-		<name>Vertical speed to pitch controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<or>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>1</value> 
-					</equals>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>2</value> 
-					</equals>
-					<equals>
-						<property>controls/autoflight/vert-mode</property>
-						<value>3</value> 
-					</equals>
-				</or>
-			</condition>
-		</enable>
-		<input>
-			<property>instrumentation/vertical-speed-indicator[0]/indicated-speed-fpm</property>
-		</input>
-		<reference>
-			<property>autopilot/internal/target-climb-rate-fpm</property>
-		</reference>
-		<output>autopilot/internal/target-pitch-deg</output>
-		<config>
-			<Kp>0.005</Kp>
-			<Ti>6</Ti>
+        <name>Vertical speed to pitch controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <or>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>1</value>
+                    </equals>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>2</value>
+                    </equals>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>3</value>
+                    </equals>
+                </or>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/vertical-speed-indicator[0]/indicated-speed-fpm</property>
+        </input>
+        <reference>
+            <property>autopilot/internal/target-climb-rate-fpm</property>
+        </reference>
+        <output>autopilot/internal/target-pitch-deg</output>
+        <config>
+            <Kp>0.005</Kp>
+            <Ti>6</Ti>
             <Td>0.7</Td>
-		</config>
-		<min>-10</min>
-		<max>10</max>
-	</pid-controller>
-	
+        </config>
+        <min>-10</min>
+        <max>10</max>
+    </pid-controller>
+
     <!--
-	<pi-simple-controller>
-		<name>Pitch controller simple test</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/autoflight-engaged</property>
-					<property>systems/hydraulic/outputs/elevator</property>
+    <pi-simple-controller>
+        <name>Pitch controller simple test</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/autoflight-engaged</property>
+                    <property>systems/hydraulic/outputs/elevator</property>
                     <greater>
                         <property>velocities/airspeed-kt</property>
                         <value>200</value>
                     </greater>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>instrumentation/attitude-indicator[0]/indicated-pitch-deg</property>
-		</input>
-		<reference>
-			<property>autopilot/internal/target-pitch-deg</property>
-		</reference>
-		<output>controls/flight/elevator-trim</output>
-		<config>
-			<Kp>-0.05</Kp>
-			<Ti>-0.10</Ti>
-		</config>
-		<min>-1</min>
-		<max>1</max>
-	</pi-simple-controller>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/attitude-indicator[0]/indicated-pitch-deg</property>
+        </input>
+        <reference>
+            <property>autopilot/internal/target-pitch-deg</property>
+        </reference>
+        <output>controls/flight/elevator-trim</output>
+        <config>
+            <Kp>-0.05</Kp>
+            <Ti>-0.10</Ti>
+        </config>
+        <min>-1</min>
+        <max>1</max>
+    </pi-simple-controller>
     -->
-	<pid-controller>
-		<name>Pitch controller</name>
-		<debug type="bool">false</debug>
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/internal/autoflight-engaged</property>
-					<property>systems/hydraulic/outputs/elevator</property>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<property>instrumentation/attitude-indicator[0]/indicated-pitch-deg</property>
-		</input>
-		<reference>
-			<property>autopilot/internal/target-pitch-deg</property>
-		</reference>
-		<output>controls/flight/elevator-trim</output>
-		<config>
-			<Kp>-0.05</Kp>
-			<beta>1</beta>
-			<alpha>0.1</alpha>
-			<gamma>0</gamma>
-			<Ti>10</Ti>
-			<Td>0.00001</Td>
-			<u_min>-1</u_min>
-			<u_max>1</u_max>
-		</config>
-	</pid-controller>
     <pid-controller>
-		<name>Roll controller</name>
-		<debug type="bool">false</debug>
-		<!-- <feedback-if-disabled>true</feedback-if-disabled> -->
-		<enable>
-			<condition>
-				<property>autopilot/internal/autoflight-engaged</property>
-			</condition>
-		</enable>
-		<input>
-			<property>instrumentation/attitude-indicator[0]/indicated-roll-deg</property>
-		</input>
-		<reference>
-			<property>autopilot/internal/target-roll-deg</property>
-		</reference>
-		<output>fcs/autopilot/aileron-cmd-norm</output>
-		<config>
-			<Kp>0.07</Kp>
-			<beta>1</beta>
-			<alpha>0.05</alpha>
-			<gamma>0.1</gamma>
-			<Ti>10</Ti>
-			<Td>0.0001</Td>
-			<u_min>-1</u_min>
-			<u_max>1</u_max>
-		</config>
-	</pid-controller>
-	
+        <name>Pitch controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/internal/autoflight-engaged</property>
+                    <property>systems/hydraulic/outputs/elevator</property>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/attitude-indicator[0]/indicated-pitch-deg</property>
+        </input>
+        <reference>
+            <property>autopilot/internal/target-pitch-deg</property>
+        </reference>
+        <output>controls/flight/elevator-trim</output>
+        <config>
+            <Kp>-0.05</Kp>
+            <beta>1</beta>
+            <alpha>0.1</alpha>
+            <gamma>0</gamma>
+            <Ti>10</Ti>
+            <Td>0.00001</Td>
+            <u_min>-1</u_min>
+            <u_max>1</u_max>
+        </config>
+    </pid-controller>
+    <pid-controller>
+        <name>Roll controller</name>
+        <debug type="bool">false</debug>
+        <!-- <feedback-if-disabled>true</feedback-if-disabled> -->
+        <enable>
+            <condition>
+                <property>autopilot/internal/autoflight-engaged</property>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/attitude-indicator[0]/indicated-roll-deg</property>
+        </input>
+        <reference>
+            <property>autopilot/internal/target-roll-deg</property>
+        </reference>
+        <output>fcs/autopilot/aileron-cmd-norm</output>
+        <config>
+            <Kp>0.07</Kp>
+            <beta>1</beta>
+            <alpha>0.05</alpha>
+            <gamma>0.1</gamma>
+            <Ti>10</Ti>
+            <Td>0.0001</Td>
+            <u_min>-1</u_min>
+            <u_max>1</u_max>
+        </config>
+    </pid-controller>
+
     <!-- Yaw damper -->
     <!-- practically doesn't work, needs an overhaul -->
     <!--
-	<filter>
-		<name>Yaw damper</name>
-		<type>gain</type>
-		<debug type="bool">false</debug>
-		<gain>0.167</gain> <!- - 5 / 30 deg - ->
-		<enable>
-			<condition>
-				<and>
-					<property>autopilot/yaw-damper-serviceable</property>
-					<or>
-						<property>controls/autoflight/yaw-damper[0]/engage</property>
-						<property>controls/autoflight/yaw-damper[1]/engage</property>
-					</or>
-				</and>
-			</condition>
-		</enable>
-		<input>
-			<expression>
-				<div>
-					<max>
-						<min>
-							<property>orientation/side-slip-deg</property>
-							<value>5</value>
-						</min>
-						<value>-5</value>
-					</max>
-					<value>5</value>
-				</div>
-			</expression>
-		</input>
-		<output>fcs/autopilot/rudder-cmd-norm</output>
-	</filter>
-	-->
+    <filter>
+        <name>Yaw damper</name>
+        <type>gain</type>
+        <debug type="bool">false</debug>
+        <gain>0.167</gain> <!- - 5 / 30 deg - ->
+        <enable>
+            <condition>
+                <and>
+                    <property>autopilot/yaw-damper-serviceable</property>
+                    <or>
+                        <property>controls/autoflight/yaw-damper[0]/engage</property>
+                        <property>controls/autoflight/yaw-damper[1]/engage</property>
+                    </or>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <expression>
+                <div>
+                    <max>
+                        <min>
+                            <property>orientation/side-slip-deg</property>
+                            <value>5</value>
+                        </min>
+                        <value>-5</value>
+                    </max>
+                    <value>5</value>
+                </div>
+            </expression>
+        </input>
+        <output>fcs/autopilot/rudder-cmd-norm</output>
+    </filter>
+    -->
 </PropertyList>

--- a/Systems/CRJ700-autopilot.xml
+++ b/Systems/CRJ700-autopilot.xml
@@ -22,7 +22,7 @@
     /controls/autoflight/lat-mode           lateral mode
     /controls/autoflight/vert-mode          vertical mode
     /controls/autoflight/speed-mode         speed mode
-    /controls/autoflight/nav-sour
+    /controls/autoflight/nav-source         nav mode
 
 
     Speed modes:

--- a/Systems/CRJ700-autopilot.xml
+++ b/Systems/CRJ700-autopilot.xml
@@ -82,7 +82,7 @@
 		<debug type="bool">false</debug>
 		<gain>1</gain>
 		<input>
-			<property>autopilot/route-manager/wp[0]/true-bearing-deg</property>
+			<property>autopilot/internal/target-crs</property>
 			<offset>
 				<property>orientation/heading-deg</property>
 				<scale>-1</scale>
@@ -720,7 +720,45 @@
 		<min>-10</min>
 		<max>10</max>
 	</pi-simple-controller>	
+    -->
+    <pid-controller>
+		<name>Vertical speed to pitch controller</name>
+		<debug type="bool">false</debug>
+		<enable>
+			<condition>
+				<or>
+					<equals>
+						<property>controls/autoflight/vert-mode</property>
+						<value>1</value> 
+					</equals>
+					<equals>
+						<property>controls/autoflight/vert-mode</property>
+						<value>2</value> 
+					</equals>
+					<equals>
+						<property>controls/autoflight/vert-mode</property>
+						<value>3</value> 
+					</equals>
+				</or>
+			</condition>
+		</enable>
+		<input>
+			<property>instrumentation/vertical-speed-indicator[0]/indicated-speed-fpm</property>
+		</input>
+		<reference>
+			<property>autopilot/internal/target-climb-rate-fpm</property>
+		</reference>
+		<output>autopilot/internal/target-pitch-deg</output>
+		<config>
+			<Kp>0.005</Kp>
+			<Ti>6</Ti>
+            <Td>0.7</Td>
+		</config>
+		<min>-10</min>
+		<max>10</max>
+	</pid-controller>
 	
+    <!--
 	<pi-simple-controller>
 		<name>Pitch controller simple test</name>
 		<debug type="bool">false</debug>
@@ -729,6 +767,10 @@
 				<and>
 					<property>autopilot/internal/autoflight-engaged</property>
 					<property>systems/hydraulic/outputs/elevator</property>
+                    <greater>
+                        <property>velocities/airspeed-kt</property>
+                        <value>200</value>
+                    </greater>
 				</and>
 			</condition>
 		</enable>
@@ -746,7 +788,7 @@
 		<min>-1</min>
 		<max>1</max>
 	</pi-simple-controller>
-<!-- 
+    -->
 	<pid-controller>
 		<name>Pitch controller</name>
 		<debug type="bool">false</debug>
@@ -776,7 +818,6 @@
 			<u_max>1</u_max>
 		</config>
 	</pid-controller>
- -->	
     <pid-controller>
 		<name>Roll controller</name>
 		<debug type="bool">false</debug>

--- a/Systems/CRJ700-autopilot.xml
+++ b/Systems/CRJ700-autopilot.xml
@@ -645,6 +645,46 @@
 		</config>
 	</pi-simple-controller>	
     <!-- Pitch and roll controllers -->
+    <pid-controller>
+        <name>Vertical speed to pitch controller</name>
+        <debug type="bool">false</debug>
+        <enable>
+            <condition>
+                <or>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>1</value>
+                    </equals>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>2</value>
+                    </equals>
+                    <equals>
+                        <property>controls/autoflight/vert-mode</property>
+                        <value>3</value>
+                    </equals>
+                </or>
+            </condition>
+        </enable>
+        <input>
+            <property>instrumentation/vertical-speed-indicator[0]/indicated-speed-fpm</property>
+        </input>
+        <reference>
+            <property>autopilot/internal/target-climb-rate-fpm</property>
+        </reference>
+        <output>autopilot/internal/target-pitch-deg</output>
+        <config>
+            <Kp>0.005</Kp>
+            <Ti>9</Ti>
+            <Td>0.55</Td>
+            <beta>0.5</beta>
+            <gamma>0.3</gamma>
+        </config>
+        <min>-10</min>
+        <max>10</max>
+    </pid-controller>
+
+    <!--
     <pi-simple-controller>
 		<name>Vertical speed to pitch controller</name>
 		<debug type="bool">false</debug>


### PR DESCRIPTION
Improvements:

- Better vertical-speed-to-pitch control: aircraft no longer sinks too fast at low speeds during IFR approach
- Better tracking of FMS/LNAV: instead of just homing in on the waypoint, or flying parallel to the leg bearing, the autopilot now intercepts the FMS track just like it would intercept a NAV radial
- Turn anticipation for LNAV (needs some work still: autopilot now just flips to the next waypoint if the current one is a fly-by waypoint and closer than a standard 1-minute turn radius: this is correct for 90-degree turns, but too early for shallower turns, and too late for sharper turns)
- I had some experimental Nasal code in there for holds, but this depends on a custom patch to FG itself, and didn't actually work, so I haven't bothered implementing any of that in the more XML-based rewrite of the autopilot stuff